### PR TITLE
 avoid workid out of bounds and generate duplicate IDS

### DIFF
--- a/src/main/java/com/baidu/fsg/uid/BitsAllocator.java
+++ b/src/main/java/com/baidu/fsg/uid/BitsAllocator.java
@@ -86,7 +86,7 @@ public class BitsAllocator {
      * @return
      */
     public long allocate(long deltaSeconds, long workerId, long sequence) {
-        return (deltaSeconds << timestampShift) | (workerId << workerIdShift) | sequence;
+        return (deltaSeconds << timestampShift) | ( (workerId%(  (~(-1L << workerIdBits)) )) << workerIdShift) | sequence;
     }
     
     /**


### PR DESCRIPTION
## Conclusion
- generate duplicate IDS

## Reproduction method
- when (1,30,18,5) , epoch= 2020-04-08
- bitsAllocator.allocate(1590229777 - 1586275200, 462146, 0)
  - uid = 33969564322693120
- bitsAllocator.allocate(1590229776 - 1586275200, 462146, 0)
  - uid = 33969564322693120

## Reasons for analysis

- when workid out of bounds
- `(deltaSeconds << timestampShift) | ( workerId  << workerIdShift)` the result is the same between two seconds


## Solution
- `workerId % (  (~(-1L << workerIdBits)))` 
-  avoid workid out of bounds
