### PR TITLE
fix(sec): upgrade org.springframework:spring-beans to 5.3.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jdk.version>1.8</jdk.version>
-        <spring.version>4.2.5.RELEASE</spring.version>
+        <spring.version>5.3.20</spring.version>
         <slf4j-version>1.7.7</slf4j-version>
     </properties>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework:spring-beans 4.2.5.RELEASE
- [CVE-2022-22965](https://www.oscs1024.com/hd/CVE-2022-22965)


### What did I do？
Upgrade org.springframework:spring-beans from 4.2.5.RELEASE to 5.3.20 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS