### PR TITLE
原因，因为项目分布式的情况下频繁启动，导致 会出现【Worker id 4194307 exceeds the max 4194303】报…

### DIFF
--- a/src/main/java/com/baidu/fsg/uid/worker/DisposableWorkerIdAssigner.java
+++ b/src/main/java/com/baidu/fsg/uid/worker/DisposableWorkerIdAssigner.java
@@ -53,8 +53,7 @@ public class DisposableWorkerIdAssigner implements WorkerIdAssigner {
         // add worker node for new (ignore the same IP + PORT)
         workerNodeDAO.addWorkerNode(workerNodeEntity);
         LOGGER.info("Add worker node:" + workerNodeEntity);
-
-        return workerNodeEntity.getId();
+        return workerNodeEntity.getId() & ~(-1L << 13);
     }
 
     /**


### PR DESCRIPTION
…错原因，所以改动了获取warkId的规则算法